### PR TITLE
Add .gitattributes file to force Unix line endings for entrypoint.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Needed for this to work on Windows without manually converting the file.