### PR TITLE
allow custom config.php location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ sed -i -e "s/max_execution_time\s*=\s*30/max_execution_time = 300/g" /etc/php/${
 sed -i -e "s/memory_limit\s*=\s*128M/memory_limit = 1G/g" /etc/php/${php}/apache2/php.ini
 EOI
 
-RUN <<EOI
+RUN bash <<EOI
 set -e
 (
     echo '<Directory /var/www/>'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get update && apt-get install -y \
     nano \
-    imagemagick \
     apache2 \
     subversion \
     ghostscript \
@@ -26,11 +25,13 @@ RUN apt-get update && apt-get install -y \
     php-mbstring \
     php-zip \
     libapache2-mod-php \
-    ffmpeg \
     libopencv-dev \
     python3-opencv \
     python3 \
     python3-pip \
+ && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    imagemagick \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM ubuntu:24.04
+ARG ubuntu=24.04
+
+FROM ubuntu:${ubuntu}
 
 LABEL org.opencontainers.image.authors="Montala Ltd"
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt-get update && apt-get install -y \
+ARG php=8.3
+
+ARG TARGETARCH
+
+RUN --mount=type=cache,id=ubuntu-${TARGETARCH},target=/var/lib/apt/lists,sharing=locked <<EOI
+set -e
+apt-get update
+apt-get install -y \
     nano \
     apache2 \
     subversion \
@@ -15,46 +24,56 @@ RUN apt-get update && apt-get install -y \
     cron \
     postfix \
     wget \
-    php \
-    php-apcu \
-    php-curl \
-    php-dev \
-    php-gd \
-    php-intl \
-    php-mysqlnd \
-    php-mbstring \
-    php-zip \
+    php${php} \
+    php${php}-apcu \
+    php${php}-curl \
+    php${php}-dev \
+    php${php}-gd \
+    php${php}-intl \
+    php${php}-ldap \
+    php${php}-mysqlnd \
+    php${php}-mbstring \
+    php${php}-zip \
     libapache2-mod-php \
     libopencv-dev \
     python3-opencv \
     python3 \
-    python3-pip \
- && apt-get install -y --no-install-recommends \
+    python3-pip
+apt-get install -y --no-install-recommends \
     ffmpeg \
-    imagemagick \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    imagemagick
+apt-get clean
+EOI
 
-RUN sed -i -e "s/upload_max_filesize\s*=\s*2M/upload_max_filesize = 100M/g" /etc/php/8.3/apache2/php.ini \
- && sed -i -e "s/post_max_size\s*=\s*8M/post_max_size = 100M/g" /etc/php/8.3/apache2/php.ini \
- && sed -i -e "s/max_execution_time\s*=\s*30/max_execution_time = 300/g" /etc/php/8.3/apache2/php.ini \
- && sed -i -e "s/memory_limit\s*=\s*128M/memory_limit = 1G/g" /etc/php/8.3/apache2/php.ini
+RUN <<EOI
+set -e
+sed -i -e "s/upload_max_filesize\s*=\s*2M/upload_max_filesize = 100M/g" /etc/php/${php}/apache2/php.ini
+sed -i -e "s/post_max_size\s*=\s*8M/post_max_size = 100M/g" /etc/php/${php}/apache2/php.ini
+sed -i -e "s/max_execution_time\s*=\s*30/max_execution_time = 300/g" /etc/php/${php}/apache2/php.ini
+sed -i -e "s/memory_limit\s*=\s*128M/memory_limit = 1G/g" /etc/php/${php}/apache2/php.ini
+EOI
 
-RUN printf '<Directory /var/www/>\n\
-\tOptions FollowSymLinks\n\
-</Directory>\n'\
->> /etc/apache2/sites-enabled/000-default.conf
+RUN <<EOI
+set -e
+(
+    echo '<Directory /var/www/>'
+    echo -e '\tOptions FollowSymLinks'
+    echo '</Directory>'
+) >>/etc/apache2/sites-enabled/000-default.conf
+EOI
 
 ADD cronjob /etc/cron.daily/resourcespace
 
 WORKDIR /var/www/html
 
-RUN rm -f index.html \
- && svn co -q https://svn.resourcespace.com/svn/rs/releases/10.7 . \
- && mkdir -p filestore \
- && chmod 777 filestore \
- && chmod -R 777 include/
- 
+RUN <<EOI
+set -e
+rm -f index.html
+svn co -q https://svn.resourcespace.com/svn/rs/releases/10.7 .
+mkdir -p filestore
+chmod 777 filestore
+chmod -R 777 include/
+EOI
 
 # Copy custom entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+# Add config.php from custom location if set
+if [[ -n "${CUSTOM_CONFIG_PHP_LOCATION}" ]]; then
+    ln -sf "${CUSTOM_CONFIG_PHP_LOCATION}" /var/ww/html/include/config.php
+fi
+
 # Start cron service
 service cron start
 
 # Ensure daily cron jobs are executable
 chmod +x /etc/cron.daily/*
 
-# Start Apache in the foreground (keeps the container alive)
-apachectl -D FOREGROUND
+# Start Apache
+service apache2 start
+
+# keeps the container alive
+tail -f /var/log/apache2/*.log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Add config.php from custom location if set
 if [[ -n "${CUSTOM_CONFIG_PHP_LOCATION}" ]]; then
-    ln -sf "${CUSTOM_CONFIG_PHP_LOCATION}" /var/ww/html/include/config.php
+    ln -sf "${CUSTOM_CONFIG_PHP_LOCATION}" /var/www/html/include/config.php
 fi
 
 # Start cron service


### PR DESCRIPTION
- allow custom config.php location (required for running other container orchestrators like AWS ECS Fargate)
- smaller docker image by removing some recommendations (e.g. x11 stuff)